### PR TITLE
Upgrade to v2.8.2 + Use the prebuilt package provided upstream

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,10 +2,10 @@
 location __PATH__/ {
 
   # Path to source
-    alias __INSTALL_DIR__/dist/;
-    index index.html;
+    alias __INSTALL_DIR__/;
+    index tools.html;
 
-    try_files $uri $uri/ /index.html;
+    try_files $uri $uri/ /tools.html;
 
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|wasm)$ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,9 +3,9 @@ location __PATH__/ {
 
   # Path to source
     alias __INSTALL_DIR__/;
-    index tools.html;
+    index index.html;
 
-    try_files $uri $uri/ /tools.html;
+    try_files $uri $uri/ /index.html;
 
 
     location ~* \.html$ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,6 +12,15 @@ location __PATH__/ {
         expires 1y;
         more_set_headers "Cache-Control: public, immutable";
     }
+    
+    # Make all app workers load
+    location ~* \.mjs$ {
+        # target only *.mjs files - we can safely override types since
+        # we are only targeting a single file extension.
+        types {
+            text/javascript mjs;
+        }
+    }
 
     # Security headers
     more_set_headers "X-Frame-Options: SAMEORIGIN always";

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "BentoPDF"
 description.en = "Privacy First PDF Toolkit"
 description.fr = "Kit d'outils PDF Privacy First"
 
-version = "2.2.1~ynh1"
+version = "2.7.0~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -43,8 +43,8 @@ ram.runtime = "150M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/alam00000/bentopdf/releases/download/v2.2.1/dist-2.2.1.zip"
-    sha256 = "6e9aed3c6e4815145d7a283834782a006dd4ad52a8de7eb0e4dd91ca4f5406b7"
+    url = "https://github.com/alam00000/bentopdf/releases/download/v2.7.0/dist-2.7.0.zip"
+    sha256 = "1d390be93be15fe9d0ea8a22bf356e5155ee72dd05be42aed3d6e7e3eb76fe17"
     format = "zip"
     extract = true
     in_subdir = false

--- a/manifest.toml
+++ b/manifest.toml
@@ -26,8 +26,8 @@ multi_instance = true
 ldap = false
 sso = false
 
-disk = "2000M"
-ram.build = "3000M"
+disk = "250M"
+ram.build = "0M"
 ram.runtime = "150M"
 
 [install]
@@ -43,10 +43,13 @@ ram.runtime = "150M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/alam00000/bentopdf/archive/refs/tags/v2.2.1.tar.gz"
-    sha256 = "8eb091ea27fc451f832999486ad6281eddafd17086197e3d2f8af09e0595a547"
-
-    autoupdate.strategy = "latest_github_tag"
+    url = "https://github.com/alam00000/bentopdf/releases/download/v2.2.1/dist-2.2.1.zip"
+    sha256 = "6e9aed3c6e4815145d7a283834782a006dd4ad52a8de7eb0e4dd91ca4f5406b7"
+    format = "zip"
+    extract = true
+    in_subdir = false
+    autoupdate.strategy = "latest_github_release"
+    autoupdate.asset = "dist-*.zip"
 
     [resources.system_user]
 
@@ -55,6 +58,3 @@ ram.runtime = "150M"
     
     [resources.permissions]
     main.url = "/"
-
-    [resources.nodejs]
-    version = "22"

--- a/manifest.toml
+++ b/manifest.toml
@@ -43,13 +43,13 @@ ram.runtime = "150M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/alam00000/bentopdf/releases/download/v2.7.0/dist-2.7.0.zip"
-    sha256 = "1d390be93be15fe9d0ea8a22bf356e5155ee72dd05be42aed3d6e7e3eb76fe17"
+    url = "https://github.com/alam00000/bentopdf/releases/download/v2.8.2/dist-simple-2.8.2.zip"
+    sha256 = "40aa4de1030c71c762df305cd9cddc3c0d2d91161b3a52c361e9d006b7cbc752"
     format = "zip"
     extract = true
     in_subdir = false
     autoupdate.strategy = "latest_github_release"
-    autoupdate.asset = "dist-*.zip"
+    autoupdate.asset = "dist-simple-*.zip"
 
     [resources.system_user]
 

--- a/scripts/install
+++ b/scripts/install
@@ -23,17 +23,6 @@ ynh_script_progression "Adding system configurations related to $app..."
 ynh_config_add_nginx
 
 #=================================================
-# INSTALL BENTOPDF
-#=================================================
-ynh_script_progression "Installing the app..."
-
-pushd "$install_dir"
-	ynh_hide_warnings ynh_exec_as_app npm install
-	ynh_hide_warnings ynh_exec_as_app SIMPLE_MODE=true npm run build
-popd
-
-#=================================================
 # END OF SCRIPT
 #=================================================
-
 ynh_script_progression "Installation of $app completed"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -11,7 +11,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --full_replace
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="config.json"
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -21,16 +21,6 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 ynh_config_add_nginx
 
 #=================================================
-# INSTALL BENTOPDF
-#=================================================
-ynh_script_progression "Installing the app..."
-
-pushd "$install_dir"
-	ynh_hide_warnings ynh_exec_as_app npm install
-	ynh_hide_warnings ynh_exec_as_app SIMPLE_MODE=true npm run build
-popd
-
-#=================================================
 # END OF SCRIPT
 #=================================================
 


### PR DESCRIPTION
Install upstream prebuilt package instead of having the YNH instance building from source. 
- Pros: faster to install, and all hardware will afford hosting it
- Cons: less customization options (or we should use workflows as in https://github.com/oleole39/prebuild-app), no control on build process.

There are still some issues:

- [x] bad links in `tools.html` which would make a better index page than the default home page, cf. https://github.com/alam00000/bentopdf/issues/483. Before this is fixed you can go to index.html where the links to the tools work fine.
   - not an issue in "simple mode" or/and v2.8.2
- [x] Workers fail to load PDFs in some tools, e.g. `compare-pdfs.html`. Not sure whether this is due to Nginx configuration or the build itself (it is working as expected on the official instance).
   - [solved](https://github.com/YunoHost-Apps/bentopdf_ynh/pull/14#discussion_r2811138316) by @Klodd
- [x] App is contacting Github API to get stars count... A kind of telemetry that should ideally be removed.
   - not an issue in "simple mode" or/and v2.8.2
- [x] WASM ressources (cf. `wasm-settings.html`) are loaded from jsdelivr.net CDN. Ideally they should be locally hosted. One way to proceed is to treat dependencies as such: https://github.com/YunoHost-Apps/jsoncrack_ynh/blob/db43e6c8d91706393fab1335b88902fc3490109e/manifest.toml#L62 even though jsdelivr.net is not currently supported by the autoupdate script.
  -  not an issue in "simple mode" or/and v2.8.2 
- [x] keep optional config.json during upgrade

CC: @ericgaspar, @Klodd 