### PR TITLE
Load MJS files properly

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,6 +7,12 @@ location __PATH__/ {
 
     try_files $uri $uri/ /index.html;
 
+    # Set correct MJS mime type as it is an unknown filetype to Nginx which
+    #   loads related files as 'application/octet-stream' type by default
+    include mime.types;
+    types {
+        application/javascript js mjs;
+    }
 
     location ~* \.html$ {
         expires 1h;
@@ -63,15 +69,6 @@ location __PATH__/ {
     location ~* \.pdf$ {
         expires 1y;
         more_set_headers "Cache-Control: public, immutable";
-    }
-    
-    # Make all app workers load
-    location ~* \.mjs$ {
-        # target only *.mjs files - we can safely override types since
-        # we are only targeting a single file extension.
-        types {
-            text/javascript mjs;
-        }
     }
 
     # Security headers


### PR DESCRIPTION
Tools are not working properly because workers try to load a `.mjs` file which is served by Nginx as `application/octet-stream` content type. This is likely to be Nginx default behavior to file extension it doesn't know (e.g. not declared in `/etc/nginx/mime.types`).

So here we're overriding `application/javascript` definition in `mime.types`  to add MJS extension for the scope of this app.

For some reason, previous patch in this direction (https://github.com/YunoHost-Apps/bentopdf_ynh/pull/14/changes/2a7820cca6bf2df03fbe8cae384cb32c25d4f2c9) does not work anymore.