### PR TITLE
Bump version to 2.8.3  (CVE fix)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "BentoPDF"
 description.en = "Privacy First PDF Toolkit"
 description.fr = "Kit d'outils PDF Privacy First"
 
-version = "2.8.2~ynh2"
+version = "2.8.3"
 
 maintainers = ["eric_G"]
 


### PR DESCRIPTION
There's a CVE that's been fixed in this version
https://github.com/alam00000/bentopdf/releases/tag/v2.8.3